### PR TITLE
Add JSON validation to make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ fix: ## Fix project.
 	@uv run ruff check --fix --unsafe-fixes
 
 .PHONY: check
-check: check/format check/lint check/types ## Run all checks.
+check: check/format check/lint check/types check/json ## Run all checks.
 
 .PHONY: check/format
 check/format:
@@ -107,6 +107,14 @@ check/lint:
 .PHONY: check/types
 check/types:
 	@uv run pyright .
+
+.PHONY: check/json
+check/json: ## Validate JSON files.
+	@echo "Checking JSON files..."
+	@find . -name "*.json" -type f \
+		! -path "./.venv/*" \
+		! -path "./node_modules/*" \
+		-exec sh -c 'jq empty "{}" > /dev/null 2>&1 || (echo "Invalid JSON: {}" && exit 1)' \;
 
 .DEFAULT_GOAL := help
 .PHONY: help


### PR DESCRIPTION
## Summary

- Adds `check/json` target that validates all JSON files using `jq`
- Includes JSON validation in `make check` workflow
- Excludes `.venv/` and `node_modules/` directories

## Why

This will catch malformed JSON files, including git conflict markers, before they are committed. The CI workflow already runs `make check`, so this validation will run automatically on all PRs.

## Test plan

- [x] Tested with `make check/json` - passes validation
- [x] Matches implementation from griptape-nodes-library-standard

🤖 Generated with [Claude Code](https://claude.com/claude-code)