### PR TITLE
Update os-model-library-setup skill to use the git CLI instead of pygit2

### DIFF
--- a/.claude/skills/os-model-library-setup/SKILL.md
+++ b/.claude/skills/os-model-library-setup/SKILL.md
@@ -154,7 +154,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pygit2
 from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
 from griptape_nodes.node_library.library_registry import Library, LibrarySchema
 
@@ -182,21 +181,18 @@ class <ClassName>LibraryAdvanced(AdvancedNodeLibrary):
             return root / ".venv" / "Scripts" / "python.exe"
         return root / ".venv" / "bin" / "python"
 
-    def _update_submodules_recursive(self, repo_path: Path) -> None:
-        repo = pygit2.Repository(str(repo_path))
-        repo.submodules.update(init=True)
-        for sub in repo.submodules:
-            sub_path = repo_path / sub.path
-            if sub_path.exists() and (sub_path / ".git").exists():
-                self._update_submodules_recursive(sub_path)
-
     def _init_submodule(self) -> Path:
         library_root = self._get_library_root()
         submodule_dir = library_root / "<submodule_name>"
         if submodule_dir.exists() and any(submodule_dir.iterdir()):
             logger.info("Submodule already initialized")
             return submodule_dir
-        self._update_submodules_recursive(library_root.parent)
+        # The git CLI rather than pygit2: the engine dropped pygit2 (its bundled TLS trust
+        # store breaks on some platforms) and requires git on PATH, so it is the one tool
+        # guaranteed to be here.
+        subprocess.check_call(
+            ["git", "-C", str(library_root.parent), "submodule", "update", "--init", "--recursive"]
+        )
         if not submodule_dir.exists() or not any(submodule_dir.iterdir()):
             raise RuntimeError(f"Submodule init failed: {submodule_dir}")
         logger.info("Submodule initialized successfully")
@@ -211,8 +207,9 @@ class <ClassName>LibraryAdvanced(AdvancedNodeLibrary):
 
     def _get_submodule_commit(self, submodule_path: Path) -> str:
         """Return the HEAD commit SHA of the submodule (the version pinned by the library author)."""
-        repo = pygit2.Repository(str(submodule_path))
-        return str(repo.head.target)
+        return subprocess.check_output(
+            ["git", "-C", str(submodule_path), "rev-parse", "HEAD"], text=True
+        ).strip()
 
     def _get_installed_sentinel(self) -> Path:
         return self._get_library_root() / ".installed_commit"
@@ -367,7 +364,7 @@ Write the new manifest JSON to `<package-dir>/griptape-nodes-library.json`. Use 
   ```
   This is **required** because many packages in the submodule's `requirements.txt` (e.g., `auto_gptq`, `flash-attn`) need torch at build time. If torch isn't installed first, pip will fail with "No module named 'torch'" during wheel builds. The `--torch-backend=auto` flag lets uv auto-detect the correct CUDA version.
 - If "Torch required: no", leave `pip_dependencies` as an empty array `[]`
-- `pygit2` is a dependency of `griptape-nodes` and is always available - no need to list it
+- Use the `git` CLI (via `subprocess`) for any git operations - the engine requires git on PATH, so it is always available. Do NOT use `pygit2`; the engine no longer ships it
 - Do NOT include `griptape-nodes` itself
 
 **Exception: submodule is sys.path-installed AND has no `requirements.txt`**

--- a/.claude/skills/os-model-library-setup/SKILL.md
+++ b/.claude/skills/os-model-library-setup/SKILL.md
@@ -187,9 +187,6 @@ class <ClassName>LibraryAdvanced(AdvancedNodeLibrary):
         if submodule_dir.exists() and any(submodule_dir.iterdir()):
             logger.info("Submodule already initialized")
             return submodule_dir
-        # The git CLI rather than pygit2: the engine dropped pygit2 (its bundled TLS trust
-        # store breaks on some platforms) and requires git on PATH, so it is the one tool
-        # guaranteed to be here.
         subprocess.check_call(
             ["git", "-C", str(library_root.parent), "submodule", "update", "--init", "--recursive"]
         )
@@ -364,7 +361,7 @@ Write the new manifest JSON to `<package-dir>/griptape-nodes-library.json`. Use 
   ```
   This is **required** because many packages in the submodule's `requirements.txt` (e.g., `auto_gptq`, `flash-attn`) need torch at build time. If torch isn't installed first, pip will fail with "No module named 'torch'" during wheel builds. The `--torch-backend=auto` flag lets uv auto-detect the correct CUDA version.
 - If "Torch required: no", leave `pip_dependencies` as an empty array `[]`
-- Use the `git` CLI (via `subprocess`) for any git operations - the engine requires git on PATH, so it is always available. Do NOT use `pygit2`; the engine no longer ships it
+- Prefer the `git` CLI via `subprocess` for git operations over adding a git library here
 - Do NOT include `griptape-nodes` itself
 
 **Exception: submodule is sys.path-installed AND has no `requirements.txt`**


### PR DESCRIPTION
Engine PR griptape-ai/griptape-nodes-engine#5265 removed `pygit2` from the engine's dependencies (its wheels bundle their own OpenSSL and mis-seed the TLS trust store). The `os-model-library-setup` skill's advanced-module template still instructed agents to `import pygit2`, which produced libraries that fail to load on current engine main — 11 existing library repos were generated with this pattern and are being migrated separately.

Update the skill's code template and guidance to the git CLI:

- `git submodule update --init --recursive` replaces the recursive pygit2 submodule walk
- `git rev-parse HEAD` replaces `pygit2.Repository(...).head.target`
- the dependency-guidance bullet now simply advises preferring the `git` CLI via `subprocess` over adding a git library to `pip_dependencies` — it no longer mentions pygit2, and makes no claim about git always being on PATH
